### PR TITLE
[#17] Feat Navigation Container Component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import './App.css';
 import Main from 'pages/Main';
+import Gallery from 'pages/Gallery';
 import Header from 'components/Header';
 
 function App() {
@@ -9,6 +10,7 @@ function App() {
       <Header></Header>
       <Routes>
         <Route path="/" element={<Main />} />
+        <Route path="/gallery/*" element={<Gallery />} />
       </Routes>
     </Router>
   );

--- a/src/components/NavigationContainer.tsx
+++ b/src/components/NavigationContainer.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+function NavigationContainer() {
+  return <Container></Container>;
+}
+
+const Container = styled.nav`
+  width: 193px;
+  height: 56rem;
+  background-color: #3584f4;
+  margin: 30px 0px 30px 30px;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export default NavigationContainer;

--- a/src/components/NavigationContainer.tsx
+++ b/src/components/NavigationContainer.tsx
@@ -5,7 +5,7 @@ function NavigationContainer() {
 }
 
 const Container = styled.nav`
-  width: 193px;
+  width: 12rem;
   height: 56rem;
   background-color: #3584f4;
   margin: 30px 0px 30px 30px;

--- a/src/components/NavigationContainer/index.tsx
+++ b/src/components/NavigationContainer/index.tsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+function NavigationContainer() {
+  return <Container></Container>;
+}
+
+const Container = styled.nav`
+  width: 12rem;
+  height: 56rem;
+  background-color: #3584f4;
+  margin: 30px 0px 30px 30px;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export default NavigationContainer;


### PR DESCRIPTION
close #17 

### ⛳️ Task

- [x] Wiki와 Gallery에서 공용으로 사용될 네비케이션 컴포넌트 퍼블리싱 

### ✍️ Note
- 추후에 작업해야 할 내용
     - 반응형 구현

### ⚡️ Test

### 📸 Screenshot
![image](https://github.com/energizer-develop/Y_FE_WIKI/assets/83440978/4f1ae325-2d90-4a26-8dfc-4a4ba039ab5d)

- 갤러리 페이지에 적용했을 때의 네비게이션 컨테이너 

### 📎 Reference
