### PR TITLE
[#6] Feat connection firebase

### DIFF
--- a/src/apis/Gallery/index.tsx
+++ b/src/apis/Gallery/index.tsx
@@ -1,0 +1,29 @@
+import { db, storage } from 'apis/firebase';
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+
+export const addFirestore = (imageURL: string, selectedCategory: string) => {
+  try {
+    addDoc(collection(db, 'gallery'), {
+      src: imageURL,
+      category: selectedCategory,
+      timestamp: serverTimestamp(),
+    });
+  } catch (error) {
+    alert(error);
+  }
+};
+
+export const addStorage = (
+  file: FileList,
+  setImageURL: React.Dispatch<React.SetStateAction<string>>,
+) => {
+  const storageRef = ref(storage, `images/${file[0].name}`);
+  const uploadTask = uploadBytes(storageRef, file[0]);
+
+  uploadTask.then((snapshot) => {
+    getDownloadURL(snapshot.ref).then((downloadURL) => {
+      setImageURL(downloadURL);
+    });
+  });
+};

--- a/src/components/UploadGallery/index.tsx
+++ b/src/components/UploadGallery/index.tsx
@@ -2,17 +2,34 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import ReactModal from 'react-modal';
 import closeButton from '../../assets/icons/closeButton.svg';
+import { addFirestore, addStorage } from 'apis/Gallery';
+import { useLocation, Link } from 'react-router-dom';
 
 function UploadGallery() {
   const [modalOpen, setModalOpen] = useState(false);
   const [preview, setPreview] = useState<string | ArrayBuffer | null>('');
+  const [imageURL, setImageURL] = useState<string>('');
+
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const selectedCategory = searchParams.get('category');
+  const url = `/gallery?category=${selectedCategory}`;
 
   const closeModal = () => {
     setModalOpen(false);
     setPreview(null);
   };
 
-  const handleChangeImg = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeImg = (
+    event: React.ChangeEvent<HTMLInputElement & EventTarget>,
+  ) => {
+    event.preventDefault();
+    const file = event.target.files;
+    console.log('file: ', file);
+    if (!file) return null;
+
+    addStorage(file, setImageURL);
+
     if (event.target.files !== null) {
       const file = event.target.files[0];
       const reader = new FileReader();
@@ -31,6 +48,7 @@ function UploadGallery() {
       return;
     }
     closeModal();
+    addFirestore(imageURL, selectedCategory as string);
   };
 
   return (
@@ -51,13 +69,13 @@ function UploadGallery() {
           onClick={closeModal}
         ></StyledCloseImg>
         <StyledContainer>
-          <StyledImgContainer>
+          <StyledPreviewContainer>
             {preview ? (
               <StyledUploadImg src={preview as string}></StyledUploadImg>
             ) : (
               <StyledImgText>⚠️ 파일을 업로드 해주세요</StyledImgText>
             )}
-          </StyledImgContainer>
+          </StyledPreviewContainer>
           <StyledButtonContainer>
             <StyledContainerInput>
               <label htmlFor="ex_file">
@@ -65,7 +83,10 @@ function UploadGallery() {
               </label>
               <input type="file" id="ex_file" onChange={handleChangeImg} />
             </StyledContainerInput>
-            <StyledImgAdd onClick={imgRegister}>사진 등록</StyledImgAdd>
+            <StyledImgAdd onClick={imgRegister}>
+              사진 등록
+              <Link to={url}></Link>
+            </StyledImgAdd>
           </StyledButtonContainer>
         </StyledContainer>
       </ReactModal>
@@ -141,7 +162,7 @@ const StyledImgText = styled.p`
   font-weight: 700;
 `;
 
-const StyledImgContainer = styled.div`
+const StyledPreviewContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
close #6 
### ⛳️ Task

- [x]  사진 Create
     - [x]  사진 업로드 버튼 구현
     - [x]  사진 업로드 모달창 구현
     - [x] 파이어베이스 연결

### ✍️ Note
- 파이어베이스와 연동을 위해 apis/Gallery/index.tsx 파일 생성
     - storage를 사용하여 이미지를 파이어베이스에 등록 후
     - firestore를 사용하여 이미지 URL을 string 형식으로 등록

- useLocation과 Link를 사용하여 사진 등록 완료시 해당 카테고리 화면으로 전환
  (현준님 코드 참고하여 많은 도움 받았습니다 🙇🏻‍♀️👍)

### ⚡️ Test

### 📸 Screenshot
- [파일 등록] 시 storage에 저장되는 이미지
![image](https://github.com/energizer-develop/Y_FE_WIKI/assets/83440978/22d53600-aad1-4a52-bcf2-d30cc9a2bdd1)

- [사진 등록하기] 버튼 클릭 시 firestore 데이터 추가
![image](https://github.com/energizer-develop/Y_FE_WIKI/assets/83440978/8e9e393d-bcca-424c-b170-7e7854c09ffb)
     - 시간순으로 정렬해줄 timestamp 필드
     - 이미지 url을 사용할 수 있도록 src 필드
     - 카테고리 필터링을 위한 category 필드

### 📎 Reference
