### PR TITLE
[#88] Fix & Refactor Wiki Component

### DIFF
--- a/src/components/NavigationWiki/index.tsx
+++ b/src/components/NavigationWiki/index.tsx
@@ -1,16 +1,23 @@
 import styled from 'styled-components';
 import { Container } from 'components/NavigationContainer';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
-function NavigationWiki() {
-  const navigate = useNavigate()
+interface props {
+  setIsChanged: React.Dispatch<React.SetStateAction<boolean>>;
+  isChange: boolean;
+}
+
+function NavigationWiki({ setIsChanged, isChange }: props) {
+  const navigate = useNavigate();
+  const searchParams = new URLSearchParams(useLocation().search);
+  const selectedCategory = searchParams.get('category');
 
   const initialCompanyInfo = [
     { id: 1, text: '회사 내규', pathName: 'companyRule' },
     { id: 2, text: '팀 소개', pathName: 'companyTeam' },
     { id: 3, text: '조직도', pathName: 'companyOrganization' },
   ];
-  
+
   const initialProjectInfo = [
     { id: 1, text: '진행중인 프로젝트', pathName: 'projects' },
     { id: 2, text: '예정된 프로젝트', pathName: 'projectsExpected' },
@@ -23,27 +30,53 @@ function NavigationWiki() {
   ];
 
   const companyList = initialCompanyInfo.map((company) => (
-    <li key={company.id} onClick={() => {
-      navigate(`/wiki?category=${company.pathName}`)
-    }}>{company.text}</li>
-  ))
+    <li
+      key={company.id}
+      className={
+        company.pathName === selectedCategory ? 'selected_category' : ''
+      }
+      onClick={() => {
+        navigate(`/wiki?category=${company.pathName}`);
+        setIsChanged(!isChange);
+      }}
+    >
+      {company.text}
+    </li>
+  ));
 
   const projectList = initialProjectInfo.map((project) => (
-    <li key={project.id} onClick={() => {
-      navigate(`/wiki?category=${project.pathName}`)
-    }}>{project.text}</li>
-  ))
+    <li
+      key={project.id}
+      className={
+        project.pathName === selectedCategory ? 'selected_category' : ''
+      }
+      onClick={() => {
+        navigate(`/wiki?category=${project.pathName}`);
+        setIsChanged(!isChange);
+      }}
+    >
+      {project.text}
+    </li>
+  ));
 
   const onBoardingList = initialOnBoardingInfo.map((onBoarding) => (
-    <li key={onBoarding.id} onClick={() => {
-      navigate(`/wiki?category=${onBoarding.pathName}`)
-    }}>{onBoarding.text}</li>
-  ))
-
+    <li
+      key={onBoarding.id}
+      className={
+        onBoarding.pathName === selectedCategory ? 'selected_category' : ''
+      }
+      onClick={() => {
+        navigate(`/wiki?category=${onBoarding.pathName}`);
+        setIsChanged(!isChange);
+      }}
+    >
+      {onBoarding.text}
+    </li>
+  ));
 
   return (
     <Container>
-      <CategoryContainer>        
+      <CategoryContainer>
         <CategoryUl>
           <h1>회사생활</h1>
           {companyList}
@@ -58,12 +91,17 @@ function NavigationWiki() {
         </CategoryUl>
       </CategoryContainer>
     </Container>
-  )
+  );
 }
 
 const CategoryContainer = styled.div`
   display: flex;
   flex-direction: column;
+
+  li:hover {
+    font-weight: 700;
+    border-bottom: 2px solid #e2e8f0;
+  }
 `;
 
 const CategoryUl = styled.ul`

--- a/src/components/Wiki/WikiCreate.tsx
+++ b/src/components/Wiki/WikiCreate.tsx
@@ -52,9 +52,7 @@ function WikiCreate({ setIsEdit, selectedCategory, data }: createProps) {
   );
 }
 
-
 export default WikiCreate;
-
 const ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
@@ -67,6 +65,7 @@ const ButtonContainer = styled.div`
 const StyledTextareaContainer = styled.div`
   margin: 2rem;
   position: relative;
+  height: 50vw;
 
   #markdownEditor {
     height: 100% !important;
@@ -84,7 +83,7 @@ const StyledTextareaContainer = styled.div`
   .document .markdownViewer::-webkit-scrollbar {
     display: none;
   }
-
+  
   ${media.desktop_lg(`
     width: 35rem;
     height: 40rem; 

--- a/src/components/Wiki/WikiCreate.tsx
+++ b/src/components/Wiki/WikiCreate.tsx
@@ -1,0 +1,108 @@
+import MDEditor from '@uiw/react-md-editor';
+import { create, update } from 'apis/Wiki';
+import { useState } from 'react';
+import styled from 'styled-components';
+import { media } from 'styles/media';
+
+interface createProps {
+  setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
+  selectedCategory: string;
+  data: any;
+}
+
+function WikiCreate({ setIsEdit, selectedCategory, data }: createProps) {
+  const isCreate = data === undefined;
+  const [textValue, setTextValue] = useState(isCreate ? '' : data.content);
+  const handleSetValue = (text: string) => {
+    if (text) {
+      setTextValue(text);
+    }
+  };
+
+  const handleWikiContent = async () => {
+    if (textValue === '') {
+      alert('빈 내용은 등록하실 수 없습니다.');
+      return;
+    }
+    if (isCreate) {
+      await create(selectedCategory, textValue);
+      setIsEdit(false);
+    } else {
+      await update(selectedCategory, textValue);
+      setIsEdit(false);
+    }
+  };
+
+  return (
+    <StyledTextareaContainer>
+      <ButtonContainer>
+        <button onClick={handleWikiContent}>
+          {isCreate ? '등록하기' : '수정하기'}
+        </button>
+      </ButtonContainer>
+      <MDEditor
+        placeholder="등록할 내용을 입력해주세요."
+        value={textValue}
+        onChange={(event) => {
+          handleSetValue(event as string);
+        }}
+        id="markdownEditor"
+      />
+    </StyledTextareaContainer>
+  );
+}
+
+
+export default WikiCreate;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  button {
+    margin: 1rem;
+  }
+`;
+
+const StyledTextareaContainer = styled.div`
+  margin: 2rem;
+  position: relative;
+
+  #markdownEditor {
+    height: 100% !important;
+  }
+
+  .document {
+    height: 100%;
+  }
+
+  .document .markdownViewer {
+    height: 100%;
+    overflow-y: scroll;
+  }
+
+  .document .markdownViewer::-webkit-scrollbar {
+    display: none;
+  }
+
+  ${media.desktop_lg(`
+    width: 35rem;
+    height: 40rem; 
+  `)}
+  ${media.tablet(`
+    width: 30rem;
+    height: 35rem;
+  `)}
+  ${media.tablet_680(`
+    width: 25rem;
+    height: 35rem;
+  `)}
+  ${media.tablet_625(`
+    width: 20rem;
+    height: 30rem;
+  `)}
+  ${media.mobile_430(`
+    width: 15rem;
+    height: 25rem;
+  `)}
+`;

--- a/src/components/Wiki/index.tsx
+++ b/src/components/Wiki/index.tsx
@@ -1,0 +1,60 @@
+import MDEditor from '@uiw/react-md-editor';
+import styled from 'styled-components';
+import { Timestamp } from 'firebase/firestore';
+
+interface loadingProps {
+  data: any;
+  setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+function WikiContent({ data, setIsEdit }: loadingProps) {
+  const time = data?.writeTime as Timestamp;
+  const documentWritedTime = time?.toDate().toString();
+
+  return (
+    <>
+      {data === undefined ? (
+        <div>
+          <h1>아직 작성된 글이 없습니다.</h1>
+          <button
+            onClick={() => {
+              setIsEdit(true);
+            }}
+          >
+            글 작성하기
+          </button>
+        </div>
+      ) : (
+        <div>
+          <StyledButtonContainer>
+            <div>
+              <button
+                onClick={() => {
+                  setIsEdit(true);
+                }}
+              >
+                수정하기
+              </button>
+              <button>삭제하기</button>
+            </div>
+          </StyledButtonContainer>
+          <p>최종 수정 시간: {documentWritedTime}</p>
+          <br />
+          <MDEditor.Markdown
+            className="markdownViewer"
+            source={data?.content}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+export default WikiContent;
+const StyledButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  button {
+    margin: 1rem;
+  }
+`;

--- a/src/components/Wiki/index.tsx
+++ b/src/components/Wiki/index.tsx
@@ -1,6 +1,8 @@
 import MDEditor from '@uiw/react-md-editor';
 import styled from 'styled-components';
 import { Timestamp } from 'firebase/firestore';
+import { wikiDelete } from 'apis/Wiki/index'
+import { media } from 'styles/media';
 
 interface loadingProps {
   data: any;
@@ -12,18 +14,18 @@ function WikiContent({ data, setIsEdit }: loadingProps) {
   const documentWritedTime = time?.toDate().toString();
 
   return (
-    <>
+    <StyledWikiContentContainer>
       {data === undefined ? (
-        <div>
+        <StyledWikiNotExist>
           <h1>아직 작성된 글이 없습니다.</h1>
           <button
             onClick={() => {
               setIsEdit(true);
             }}
           >
-            글 작성하기
+            + 글 작성하기
           </button>
-        </div>
+        </StyledWikiNotExist>
       ) : (
         <div>
           <StyledButtonContainer>
@@ -35,7 +37,13 @@ function WikiContent({ data, setIsEdit }: loadingProps) {
               >
                 수정하기
               </button>
-              <button>삭제하기</button>
+              <button
+                onClick={() => {
+                  wikiDelete(data?.subject);
+                }}
+              >
+                삭제하기
+              </button>
             </div>
           </StyledButtonContainer>
           <p>최종 수정 시간: {documentWritedTime}</p>
@@ -46,7 +54,7 @@ function WikiContent({ data, setIsEdit }: loadingProps) {
           />
         </div>
       )}
-    </>
+    </StyledWikiContentContainer>
   );
 }
 export default WikiContent;
@@ -57,4 +65,59 @@ const StyledButtonContainer = styled.div`
   button {
     margin: 1rem;
   }
+`;
+
+const StyledWikiContentContainer = styled.div`
+  width: 100%;
+`;
+
+
+const StyledWikiNotExist = styled.div`
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+  position: absolute;
+
+  width: 100%;
+  height: 100%;
+  top: 50%; 
+
+  button {
+    position: relative;
+    color: #3584f4;
+    font-size: 1rem;
+    text-align: right;
+    cursor: pointer;
+  }
+
+  ${media.desktop_lg(`
+    font-size: 1.5rem;
+    button {
+      left: 13rem;
+    }
+  `)}
+  ${media.tablet(`
+    font-size: 1.25rem;
+    button {
+      left: 10rem;
+    }
+  `)}
+  ${media.tablet_680(`
+    font-size: 1rem;
+    button {
+      left: 7.5rem;
+    }
+  `)}
+  ${media.tablet_625(`
+    font-size: 0.75rem;
+    button {
+      left: 5rem;
+    }
+  `)}
+  ${media.mobile_430(`
+    font-size: 0.5rem;
+    button {
+      left: 2.5rem;
+    }
+  `)}
 `;

--- a/src/pages/Wiki/index.tsx
+++ b/src/pages/Wiki/index.tsx
@@ -1,110 +1,19 @@
 import NavigationWiki from 'components/NavigationWiki';
 import styled from 'styled-components';
-import MDEditor from '@uiw/react-md-editor';
 import { useState, useEffect } from 'react';
-import { create, read } from 'apis/Wiki';
+import {  read } from 'apis/Wiki';
 import { useLocation } from 'react-router-dom';
-// import { Timestamp } from 'firebase/firestore';
 import { media } from 'styles/media';
 import Loading from 'components/Common/Loading';
 import WikiContent from 'components/Wiki/'
-
-
-interface createProps {
-  setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-// interface updateProps {
-//   setIsUpdate: React.Dispatch<React.SetStateAction<boolean>>;
-// }
-
-function WikiCreate({ setIsEdit }: createProps) {
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-  let selectedCategory = searchParams.get('category');
-  if (selectedCategory === null) selectedCategory = 'companyRule';
-  const [textValue, setTextValue] = useState('');
-  const handleSetValue = (text: string) => {
-    if (text) {
-      setTextValue(text);
-    }
-  };
-
-  return (
-    <StyledTextareaContainer>
-      <ButtonContainer>
-        <button
-          onClick={() => {
-            if (textValue === '') {
-              alert('빈 내용은 등록하실 수 없습니다.');
-              return;
-            }
-            create(selectedCategory as string, textValue);
-            setIsEdit(false);
-          }}
-        >
-          등록하기
-        </button>
-      </ButtonContainer>
-      <MDEditor
-        placeholder="등록할 내용을 입력해주세요."
-        value={textValue}
-        onChange={(event) => {
-          handleSetValue(event as string);
-        }}
-        id="markdownEditor"
-      />
-    </StyledTextareaContainer>
-  );
-}
-
-// function WikiUpdate({ setIsUpdate }: updateProps) {
-//   const location = useLocation();
-//   const searchParams = new URLSearchParams(location.search);
-//   let selectedCategory = searchParams.get('category');
-//   if (selectedCategory === null) selectedCategory = 'companyRule';
-//   const [textValue, setTextValue] = useState('');
-//   const handleSetValue = (text: string) => {
-//     if (text) {
-//       setTextValue(text);
-//     }
-//   };
-
-//   return (
-//     <StyledTextareaContainer>
-//       <ButtonContainer>
-//         <button
-//           onClick={() => {
-//             if (textValue === '') {
-//               alert('빈 내용은 등록하실 수 없습니다.');
-//               return;
-//             }
-//             update(selectedCategory as string, textValue);
-//             setIsUpdate(false);
-//           }}
-//         >
-//           등록하기
-//         </button>
-//       </ButtonContainer>
-//       <MDEditor
-//         placeholder="등록할 내용을 입력해주세요."
-//         value={textValue}
-//         onChange={(event) => {
-//           handleSetValue(event as string);
-//         }}
-//         id="markdownEditor"
-//       />
-//     </StyledTextareaContainer>
-//   );
-// }
+import WikiCreate from 'components/Wiki'
 
 function Wiki() {
   const [isEdit, setIsEdit] = useState(false);
-  // const [isUpdate, setIsUpdate] = useState(false);
-  // const [isDocumentExist, setDocumentExist] = useState(false);
   const [data, setData] = useState(Object);
-  // const [documentTime, setDocumentTime] = useState('');
+  // const [isChange, setIsChanged] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   let selectedCategory = searchParams.get('category');
@@ -112,86 +21,44 @@ function Wiki() {
 
   const getDocumentList = async () => {
     setIsLoading(true)
-    const document = await read(selectedCategory as string);
-    // document === undefined ? setDocumentExist(false) : setDocumentExist(true);
+    if (selectedCategory === null) return;
+    const document = await read(selectedCategory);
     setData(document);
-    // const time = document?.writeTime as Timestamp;
-    // if (time) {
-    //   setDocumentTime(time.toDate().toString());
-    // }
     setIsLoading(false)
   };
 
   useEffect(() => {
-    const fetchData = async () => {
-      const documentData = await getDocumentList();
-      return documentData;
-    };
-    fetchData();
-  }, [selectedCategory]);
+    getDocumentList();
+  }, [isEdit]);
+
+  // useEffect(() => {
+  //   if (isEdit) setIsEdit(false);
+  //   getDocumentList();
+  // }, [isChange])
 
   return (
     <StyledWikiContainer>
-      <NavigationWiki></NavigationWiki>
-
-      {isEdit === true ? (
-        <WikiCreate setIsEdit={setIsEdit}></WikiCreate>
-      ) : (
-        <StyledTextareaContainer>
-          {isLoading ? (
-            <Loading></Loading>
-          ) : (
-            <WikiContent data={data} setIsEdit={setIsEdit} />
-          )}
-          {
-            <></> /* {isDocumentExist === false ? (
-            <StyledWikiNotExist>
-              <h1>아직 등록된 글이 없습니다.</h1>
-              <button
-                onClick={() => {
-                  setIsEdit(true);
-                }}
-              >
-                + 글 작성하기
-              </button>
-            </StyledWikiNotExist>
-          ) : (
-            <div className="document">
-              {isUpdate === true ? (
-                <WikiUpdate setIsUpdate={setIsUpdate}></WikiUpdate>
-              ) : (
-                <div>
-                  <ButtonContainer>
-                    <div>
-                      <button
-                        onClick={() => {
-                          setIsUpdate(true);
-                        }}
-                      >
-                        수정하기
-                      </button>
-                      <button
-                        onClick={() => {
-                          wikiDelete(selectedCategory as string);
-                        }}
-                      >
-                        삭제하기
-                      </button>
-                    </div>
-                  </ButtonContainer>
-                  <p>최종 수정 시간: {documentTime}</p>
-                  <br />
-                  <MDEditor.Markdown
-                    className="markdownViewer"
-                    source={data?.content}
-                  />
-                </div>
-              )}
-            </div>
-          )} */
-          }
-        </StyledTextareaContainer>
-      )}
+      <NavigationWiki
+        // setIsChanged={setIsChanged}
+        // isChange={isChange}
+      ></NavigationWiki>
+      <div>
+        {isEdit ? (
+          <WikiCreate
+            setIsEdit={setIsEdit}
+            data={data}
+            // selectedCategory={selectedCategory}
+          ></WikiCreate>
+        ) : (
+          <StyledTextareaContainer>
+            {isLoading ? (
+              <Loading></Loading>
+            ) : (
+              <WikiContent data={data} setIsEdit={setIsEdit} />
+            )}
+          </StyledTextareaContainer>
+        )}
+      </div>
     </StyledWikiContainer>
   );
 }
@@ -202,14 +69,6 @@ const StyledWikiContainer = styled.div`
   grid-template-columns: 0.2fr 0.8fr;
 `;
 
-const ButtonContainer = styled.div`
-  display: flex;
-  justify-content: flex-end;
-
-  button {
-    margin: 1rem;
-  }
-`;
 
 const StyledTextareaContainer = styled.div`
   margin: 2rem;

--- a/src/pages/Wiki/index.tsx
+++ b/src/pages/Wiki/index.tsx
@@ -6,6 +6,7 @@ import { create, read } from 'apis/Wiki';
 import { useLocation } from 'react-router-dom';
 // import { Timestamp } from 'firebase/firestore';
 import { media } from 'styles/media';
+import Loading from 'components/Common/Loading';
 import WikiContent from 'components/Wiki/'
 
 
@@ -103,12 +104,14 @@ function Wiki() {
   // const [isDocumentExist, setDocumentExist] = useState(false);
   const [data, setData] = useState(Object);
   // const [documentTime, setDocumentTime] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   let selectedCategory = searchParams.get('category');
   if (selectedCategory === null) selectedCategory = 'companyRule';
 
   const getDocumentList = async () => {
+    setIsLoading(true)
     const document = await read(selectedCategory as string);
     // document === undefined ? setDocumentExist(false) : setDocumentExist(true);
     setData(document);
@@ -116,6 +119,7 @@ function Wiki() {
     // if (time) {
     //   setDocumentTime(time.toDate().toString());
     // }
+    setIsLoading(false)
   };
 
   useEffect(() => {
@@ -134,7 +138,11 @@ function Wiki() {
         <WikiCreate setIsEdit={setIsEdit}></WikiCreate>
       ) : (
         <StyledTextareaContainer>
-          <WikiContent data={data} setIsEdit={setIsEdit} />
+          {isLoading ? (
+            <Loading></Loading>
+          ) : (
+            <WikiContent data={data} setIsEdit={setIsEdit} />
+          )}
           {
             <></> /* {isDocumentExist === false ? (
             <StyledWikiNotExist>

--- a/src/pages/Wiki/index.tsx
+++ b/src/pages/Wiki/index.tsx
@@ -1,7 +1,7 @@
 import NavigationWiki from 'components/NavigationWiki';
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
-import {  read } from 'apis/Wiki';
+import { read } from 'apis/Wiki';
 import { useLocation } from 'react-router-dom';
 import { media } from 'styles/media';
 import Loading from 'components/Common/Loading';

--- a/src/pages/Wiki/index.tsx
+++ b/src/pages/Wiki/index.tsx
@@ -5,13 +5,13 @@ import {  read } from 'apis/Wiki';
 import { useLocation } from 'react-router-dom';
 import { media } from 'styles/media';
 import Loading from 'components/Common/Loading';
-import WikiContent from 'components/Wiki/'
-import WikiCreate from 'components/Wiki'
+import WikiContent from 'components/Wiki/index'
+import WikiCreate from 'components/Wiki/WikiCreate'
 
 function Wiki() {
   const [isEdit, setIsEdit] = useState(false);
   const [data, setData] = useState(Object);
-  // const [isChange, setIsChanged] = useState(false);
+  const [isChange, setIsChanged] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const location = useLocation();
@@ -31,23 +31,23 @@ function Wiki() {
     getDocumentList();
   }, [isEdit]);
 
-  // useEffect(() => {
-  //   if (isEdit) setIsEdit(false);
-  //   getDocumentList();
-  // }, [isChange])
+  useEffect(() => {
+    if (isEdit) setIsEdit(false);
+    getDocumentList();
+  }, [isChange])
 
   return (
     <StyledWikiContainer>
       <NavigationWiki
-        // setIsChanged={setIsChanged}
-        // isChange={isChange}
+        setIsChanged={setIsChanged}
+        isChange={isChange}
       ></NavigationWiki>
       <div>
         {isEdit ? (
           <WikiCreate
             setIsEdit={setIsEdit}
             data={data}
-            // selectedCategory={selectedCategory}
+            selectedCategory={selectedCategory}
           ></WikiCreate>
         ) : (
           <StyledTextareaContainer>

--- a/src/pages/Wiki/index.tsx
+++ b/src/pages/Wiki/index.tsx
@@ -1,55 +1,23 @@
 import NavigationWiki from 'components/NavigationWiki';
 import styled from 'styled-components';
 import MDEditor from '@uiw/react-md-editor';
-import { useState, useEffect } from 'react'
-import { create, read, update, wikiDelete } from 'apis/Wiki';
-import { useLocation } from 'react-router-dom'
-import { Timestamp } from 'firebase/firestore'
+import { useState, useEffect } from 'react';
+import { create, read } from 'apis/Wiki';
+import { useLocation } from 'react-router-dom';
+// import { Timestamp } from 'firebase/firestore';
+import { media } from 'styles/media';
+import WikiContent from 'components/Wiki/'
+
 
 interface createProps {
   setIsEdit: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-interface updateProps {
-  setIsUpdate: React.Dispatch<React.SetStateAction<boolean>>;
-}
+// interface updateProps {
+//   setIsUpdate: React.Dispatch<React.SetStateAction<boolean>>;
+// }
 
 function WikiCreate({ setIsEdit }: createProps) {
-  const location = useLocation()
-  const searchParams = new URLSearchParams(location.search)
-  let selectedCategory = searchParams.get('category')
-  if (selectedCategory === null) selectedCategory = 'companyRule'
-  const [textValue, setTextValue] = useState('')  
-  const handleSetValue = (text: string) => {
-    if (text) {
-      setTextValue(text);
-    }
-  };
-
-  return (
-    <TextareaContainer>
-      <ButtonContainer>
-        <button onClick={() => {
-          if (textValue === '') {
-            alert('빈 내용은 등록하실 수 없습니다.')
-            return;
-          }
-          create(selectedCategory as string, textValue)
-          setIsEdit(false)
-        }}>등록하기</button>
-      </ButtonContainer>
-      <MDEditor
-        placeholder='등록할 내용을 입력해주세요.'
-        value={textValue}
-        onChange={(event) => {handleSetValue(event as string)}}
-        id='markdownEditor'
-      />
-    </TextareaContainer>
-  )  
-}
-
-
-function WikiUpdate({ setIsUpdate }: updateProps) {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   let selectedCategory = searchParams.get('category');
@@ -62,7 +30,7 @@ function WikiUpdate({ setIsUpdate }: updateProps) {
   };
 
   return (
-    <TextareaContainer>
+    <StyledTextareaContainer>
       <ButtonContainer>
         <button
           onClick={() => {
@@ -70,8 +38,8 @@ function WikiUpdate({ setIsUpdate }: updateProps) {
               alert('빈 내용은 등록하실 수 없습니다.');
               return;
             }
-            update(selectedCategory as string, textValue);
-            setIsUpdate(false);
+            create(selectedCategory as string, textValue);
+            setIsEdit(false);
           }}
         >
           등록하기
@@ -85,17 +53,56 @@ function WikiUpdate({ setIsUpdate }: updateProps) {
         }}
         id="markdownEditor"
       />
-    </TextareaContainer>
+    </StyledTextareaContainer>
   );
 }
 
+// function WikiUpdate({ setIsUpdate }: updateProps) {
+//   const location = useLocation();
+//   const searchParams = new URLSearchParams(location.search);
+//   let selectedCategory = searchParams.get('category');
+//   if (selectedCategory === null) selectedCategory = 'companyRule';
+//   const [textValue, setTextValue] = useState('');
+//   const handleSetValue = (text: string) => {
+//     if (text) {
+//       setTextValue(text);
+//     }
+//   };
+
+//   return (
+//     <StyledTextareaContainer>
+//       <ButtonContainer>
+//         <button
+//           onClick={() => {
+//             if (textValue === '') {
+//               alert('빈 내용은 등록하실 수 없습니다.');
+//               return;
+//             }
+//             update(selectedCategory as string, textValue);
+//             setIsUpdate(false);
+//           }}
+//         >
+//           등록하기
+//         </button>
+//       </ButtonContainer>
+//       <MDEditor
+//         placeholder="등록할 내용을 입력해주세요."
+//         value={textValue}
+//         onChange={(event) => {
+//           handleSetValue(event as string);
+//         }}
+//         id="markdownEditor"
+//       />
+//     </StyledTextareaContainer>
+//   );
+// }
 
 function Wiki() {
   const [isEdit, setIsEdit] = useState(false);
-  const [isUpdate, setIsUpdate] = useState(false);
-  const [isDocumentExist, setDocumentExist] = useState(false);
+  // const [isUpdate, setIsUpdate] = useState(false);
+  // const [isDocumentExist, setDocumentExist] = useState(false);
   const [data, setData] = useState(Object);
-  const [documentTime, setDocumentTime] = useState('');
+  // const [documentTime, setDocumentTime] = useState('');
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   let selectedCategory = searchParams.get('category');
@@ -103,12 +110,12 @@ function Wiki() {
 
   const getDocumentList = async () => {
     const document = await read(selectedCategory as string);
-    document === undefined ? setDocumentExist(false) : setDocumentExist(true);
+    // document === undefined ? setDocumentExist(false) : setDocumentExist(true);
     setData(document);
-    const time = document?.writeTime as Timestamp;
-    if (time) {
-      setDocumentTime(time.toDate().toString());
-    }
+    // const time = document?.writeTime as Timestamp;
+    // if (time) {
+    //   setDocumentTime(time.toDate().toString());
+    // }
   };
 
   useEffect(() => {
@@ -120,64 +127,71 @@ function Wiki() {
   }, [selectedCategory]);
 
   return (
-    <WikiContainer>
+    <StyledWikiContainer>
       <NavigationWiki></NavigationWiki>
-      <div>
-        {isEdit === true ? (
-          <WikiCreate setIsEdit={setIsEdit}></WikiCreate>
-        ) : (
-          <TextareaContainer>
-            {isDocumentExist === false ? (
-              <div
+
+      {isEdit === true ? (
+        <WikiCreate setIsEdit={setIsEdit}></WikiCreate>
+      ) : (
+        <StyledTextareaContainer>
+          <WikiContent data={data} setIsEdit={setIsEdit} />
+          {
+            <></> /* {isDocumentExist === false ? (
+            <StyledWikiNotExist>
+              <h1>아직 등록된 글이 없습니다.</h1>
+              <button
                 onClick={() => {
                   setIsEdit(true);
                 }}
               >
-                <h1>아직 작성된 글이 없습니다.</h1>글 작성하기
-              </div>
-            ) : (
-              <div className="document">
-                {isUpdate === true ? (
-                  <WikiUpdate
-                    setIsUpdate={setIsUpdate}
-                  ></WikiUpdate>
-                ) : (
-                  <div>
-                    <ButtonContainer>
-                      <div>
-                        <button
-                          onClick={() => {
-                            setIsUpdate(true);
-                          }}
-                        >
-                          수정하기
-                        </button>
-                        <button onClick={() => {
-                          wikiDelete(selectedCategory as string)
-                        }}>삭제하기</button>
-                      </div>
-                    </ButtonContainer>
-                    <p>최종 수정 시간: {documentTime}</p>
-                    <br />
-                    <MDEditor.Markdown
-                      className="markdownViewer"
-                      source={data?.content}
-                    />
-                  </div>
-                )}
-              </div>
-            )}
-          </TextareaContainer>
-        )}
-      </div>
-    </WikiContainer>
+                + 글 작성하기
+              </button>
+            </StyledWikiNotExist>
+          ) : (
+            <div className="document">
+              {isUpdate === true ? (
+                <WikiUpdate setIsUpdate={setIsUpdate}></WikiUpdate>
+              ) : (
+                <div>
+                  <ButtonContainer>
+                    <div>
+                      <button
+                        onClick={() => {
+                          setIsUpdate(true);
+                        }}
+                      >
+                        수정하기
+                      </button>
+                      <button
+                        onClick={() => {
+                          wikiDelete(selectedCategory as string);
+                        }}
+                      >
+                        삭제하기
+                      </button>
+                    </div>
+                  </ButtonContainer>
+                  <p>최종 수정 시간: {documentTime}</p>
+                  <br />
+                  <MDEditor.Markdown
+                    className="markdownViewer"
+                    source={data?.content}
+                  />
+                </div>
+              )}
+            </div>
+          )} */
+          }
+        </StyledTextareaContainer>
+      )}
+    </StyledWikiContainer>
   );
 }
 
 
-const WikiContainer = styled.div`
+const StyledWikiContainer = styled.div`
   display: grid;
-  grid-template-columns: 0.2fr 0.8fr
+  grid-template-columns: 0.2fr 0.8fr;
 `;
 
 const ButtonContainer = styled.div`
@@ -189,10 +203,9 @@ const ButtonContainer = styled.div`
   }
 `;
 
-const TextareaContainer = styled.div`
+const StyledTextareaContainer = styled.div`
   margin: 2rem;
   position: relative;
-  height: 50vw;
 
   #markdownEditor {
     height: 100% !important;
@@ -210,6 +223,62 @@ const TextareaContainer = styled.div`
   .document .markdownViewer::-webkit-scrollbar {
     display: none;
   }
+
+  ${media.desktop_lg(`
+    width: 35rem;
+    height: 40rem; 
+  `)}
+  ${media.tablet(`
+    width: 30rem;
+    height: 35rem;
+  `)}
+  ${media.tablet_680(`
+    width: 25rem;
+    height: 35rem;
+  `)}
+  ${media.tablet_625(`
+    width: 20rem;
+    height: 30rem;
+  `)}
+  ${media.mobile_430(`
+    width: 15rem;
+    height: 25rem;
+  `)}
 `;
+
+// const StyledWikiNotExist = styled.div`
+//   font-size: 1.5rem;
+//   font-weight: 600;
+//   text-align: center;
+//   position: absolute;
+
+//   width: 100%;
+//   height: 100%;
+//   top: 50%;
+
+//   button {
+//     position: relative;
+//     color: #3584f4;
+//     font-size: 1rem;
+//     text-align: right;
+//     cursor: pointer;
+//   }
+
+//   ${media.desktop_lg(`
+//     font-size: 1.5rem;
+//   `)}
+//   ${media.tablet(`
+//     font-size: 1.25rem;
+//   `)}
+//   ${media.tablet_680(`
+//     font-size: 1rem;
+//   `)}
+//   ${media.tablet_625(`
+//     font-size: 0.75rem;
+//   `)}
+//   ${media.mobile_430(`
+//     font-size: 0.5rem;
+//   `)}
+// `;
 
 export default Wiki;


### PR DESCRIPTION
### ⛳️ Task
위키 페이지 내 수정/리팩토링을 진행합니다.
전반적으로 https://github.com/energizer-develop/Y_FE_WIKI/pull/83 에서 남겨주신 내용을 최대한 활용하고, 이해해가면서 진행해보았습니다!
- [ ] 글 작성하기 버튼 cursor pointer 및 중앙 배치
- 와이어프레임에 맞게 최대한 수정하고 있는데요, 아직 해상도에 따른 반응형 디자인이 전부 적용되지 않은 상태입니다.
- [x] 사이드바에서 현재 위치한 카테고리 차별점 두기
  - [x] https://github.com/energizer-develop/Y_FE_WIKI/pull/84 PR에서의 디자인을 적용합니다.
  - 수빈님께서 적용하신 스타일링을 동일하게 적용하였습니다!
- [x] wiki 컴포넌트 내부 로딩 구현
- [x] 단언 제거 
- 불필요한 타입 단언은 최대한 수정하였지만, 부득이하게 사용한 부분이 있었습니다.
```
const time = data?.writeTime as Timestamp;
  const documentWritedTime = time?.toDate().toString();
```
위의 코드에서 작성 시간을 firebase에서 제공하는 serverTimeStamp를 사용해 저장하는데, Date 객체로 바로 변환이 되지 않아 부득이하게 사용했습니다. 수정 가능한 방향 최대한 찾아보고 수정하려 합니다!
- [x] edit 중일 때 category 클릭 시 category가 변경 안되는 문제 해결
- [x] 수정할 때 이전에 작성했던 내용을 input 값에 할당 ( 이어서 작성할 수 있게!)
- [x] 등록하기 or 수정하기 클릭했을 때 이전의 내용을 보여주었다가 loading 후 새로운 내용을 보여주는 문제 해결 ( 등록하기 or 수정하기 클릭하면 loading 후 새로운 내용 보여주도록 변경)
### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
