### PR TITLE
[#101] Refactor Wiki

### DIFF
--- a/src/components/NavigationWiki/index.tsx
+++ b/src/components/NavigationWiki/index.tsx
@@ -25,9 +25,9 @@ function NavigationWiki({ setIsChanged, isChange }: INavigationWikiProps) {
 
   return (
     <Container>
-      <CategoryContainer>
+      <StyledCategoryContainer>
         {CATEGORY.map((category: ICategory, categoryIndex) => (
-          <CategoryUl key={categoryIndex}>
+          <StyledCategoryUl key={categoryIndex}>
             <h1>회사생활</h1>
             {category.info.map((info, infoIndex) => (
               <span
@@ -43,19 +43,19 @@ function NavigationWiki({ setIsChanged, isChange }: INavigationWikiProps) {
                 {info.text}
               <br/><br/></span>
             ))}
-          </CategoryUl>
+          </StyledCategoryUl>
         ))}
-      </CategoryContainer>
+      </StyledCategoryContainer>
     </Container>
   );
 }
 
-const CategoryContainer = styled.div`
+const StyledCategoryContainer = styled.div`
   display: flex;
   flex-direction: column;
 `;
 
-const CategoryUl = styled.ul`
+const StyledCategoryUl = styled.ul`
   padding: 0;
   color: white;
   margin-top: 2rem;

--- a/src/components/NavigationWiki/index.tsx
+++ b/src/components/NavigationWiki/index.tsx
@@ -30,7 +30,7 @@ function NavigationWiki({ setIsChanged, isChange }: INavigationWikiProps) {
           <CategoryUl key={categoryIndex}>
             <h1>회사생활</h1>
             {category.info.map((info, infoIndex) => (
-              <li
+              <span
                 key={infoIndex}
                 className={
                   info.pathName === selectedCategory ? 'selected_category' : ''
@@ -41,7 +41,7 @@ function NavigationWiki({ setIsChanged, isChange }: INavigationWikiProps) {
                 }}
               >
                 {info.text}
-              </li>
+              <br/><br/></span>
             ))}
           </CategoryUl>
         ))}
@@ -60,13 +60,16 @@ const CategoryUl = styled.ul`
   color: white;
   margin-top: 2rem;
 
-  li {
-    list-style: none;
-    margin: 1rem 0 1rem 1rem;
+  h1 {
+    margin-bottom: 1rem;
+  }
+
+  span {
+    margin: 1rem;
     cursor: default;
   }
 
-  li:hover {
+  span:hover {
     cursor: pointer;
   }
   .selected_category {

--- a/src/components/NavigationWiki/index.tsx
+++ b/src/components/NavigationWiki/index.tsx
@@ -3,6 +3,7 @@ import { Container } from 'components/NavigationContainer';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { ROUTES } from 'constants/routes';
 import { CATEGORY } from 'constants/wiki';
+import { media } from 'styles/media';
 
 interface INavigationWikiProps {
   setIsChanged: React.Dispatch<React.SetStateAction<boolean>>;
@@ -24,7 +25,7 @@ function NavigationWiki({ setIsChanged, isChange }: INavigationWikiProps) {
   const selectedCategory = searchParams.get('category');
 
   return (
-    <Container>
+    <StyledWikiContainer>
       <StyledCategoryContainer>
         {CATEGORY.map((category: ICategory, categoryIndex) => (
           <StyledCategoryUl key={categoryIndex}>
@@ -46,9 +47,27 @@ function NavigationWiki({ setIsChanged, isChange }: INavigationWikiProps) {
           </StyledCategoryUl>
         ))}
       </StyledCategoryContainer>
-    </Container>
+    </StyledWikiContainer>
   );
 }
+
+const StyledWikiContainer = styled(Container) `
+  ${media.desktop_lg(`
+    width: 10rem;
+  `)}
+  ${media.tablet(`
+    width: 8rem;
+  `)}
+  ${media.tablet_680(`
+    width: 7rem;
+  `)}
+  ${media.tablet_625(`
+    width: 6rem;
+  `)}
+  ${media.mobile_430(`
+    width: 5rem;
+  `)}  
+`;
 
 const StyledCategoryContainer = styled.div`
   display: flex;
@@ -58,7 +77,7 @@ const StyledCategoryContainer = styled.div`
 const StyledCategoryUl = styled.ul`
   padding: 0;
   color: white;
-  margin-top: 2rem;
+  margin: 2rem 0 0 0.25rem;
 
   h1 {
     margin-bottom: 1rem;
@@ -68,7 +87,7 @@ const StyledCategoryUl = styled.ul`
     margin: 1rem;
     cursor: default;
   }
-
+  
   span:hover {
     cursor: pointer;
   }
@@ -76,6 +95,22 @@ const StyledCategoryUl = styled.ul`
     font-weight: 700;
     border-bottom: 2px solid #e2e8f0;
   }
+  
+  ${media.desktop_lg(`
+    font-size: 1rem;
+  `)}
+  ${media.tablet(`
+    font-size: 0.9rem;
+  `)}
+  ${media.tablet_680(`
+    font-size: 0.8rem;
+  `)}
+  ${media.tablet_625(`
+    font-size: 0.5rem;
+  `)}
+  ${media.mobile_430(`
+    font-size: 0.4rem;
+  `)}
 `;
 
 export default NavigationWiki;

--- a/src/components/Wiki/WikiContent.tsx
+++ b/src/components/Wiki/WikiContent.tsx
@@ -74,7 +74,15 @@ const StyledButtonContainer = styled.div`
   justify-content: flex-end;
 
   button {
-    margin: 1rem;
+    margin: 0.5rem;
+    // color: #3584f4;
+    border: 1px solid rgb(226, 232, 240);
+    padding: 0.5rem;
+    border-radius: 1rem;
+  }
+
+  button:hover {
+    background-color: rgb(237, 242, 247);
   }
 `;
 

--- a/src/components/Wiki/WikiContent.tsx
+++ b/src/components/Wiki/WikiContent.tsx
@@ -75,7 +75,6 @@ const StyledButtonContainer = styled.div`
 
   button {
     margin: 0.5rem;
-    // color: #3584f4;
     border: 1px solid rgb(226, 232, 240);
     padding: 0.5rem;
     border-radius: 1rem;

--- a/src/components/Wiki/WikiCreate.tsx
+++ b/src/components/Wiki/WikiCreate.tsx
@@ -58,7 +58,14 @@ const StyledButtonContainer = styled.div`
   justify-content: flex-end;
 
   button {
-    margin: 1rem;
+    margin: 1rem 0 1rem 1rem;
+    border: 1px solid rgb(226, 232, 240);
+    padding: 0.5rem;
+    border-radius: 1rem;
+  }
+
+  button:hover {
+    background-color: rgb(237, 242, 247);
   }
 `;
 

--- a/src/components/Wiki/WikiCreate.tsx
+++ b/src/components/Wiki/WikiCreate.tsx
@@ -35,11 +35,11 @@ function WikiCreate({ setIsEdit, selectedCategory, data }: createProps) {
 
   return (
     <StyledTextareaContainer>
-      <ButtonContainer>
+      <StyledButtonContainer>
         <button onClick={handleWikiContent}>
           {isCreate ? '등록하기' : '수정하기'}
         </button>
-      </ButtonContainer>
+      </StyledButtonContainer>
       <MDEditor
         placeholder="등록할 내용을 입력해주세요."
         value={textValue}
@@ -53,7 +53,7 @@ function WikiCreate({ setIsEdit, selectedCategory, data }: createProps) {
 }
 
 export default WikiCreate;
-const ButtonContainer = styled.div`
+const StyledButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
 


### PR DESCRIPTION
close #101 
### ⛳️ Task

- [x] 네비게이션 바 선택한 카테고리 밑줄 영역 조절
  - 기존에는 네비게이션 바 내 세부 카테고리 항목들이 li 요소에 들어가 있었고, 블록 요소이다 보니 border-bottom에 해당하는 영역이 li 요소의 너비 전체로 지정되어 차이가 발생했습니다!
  - li 요소를 span으로 변경해서 필요한 부분만큼만 border-bottom 속성 값이 적용되게끔 바꾸어보았습니다.  
- [x] 위키 페이지 네비게이션 바 크기 조정
  - 모바일 고려해서 네비게이션 바 크기 조정 진행했습니다.
- [x] 버튼 디자인
  - 삭제하기, 수정하기, 등록하기 부분 버튼 디자인 없이 텍스트로만 남겨뒀던 부분 버튼 디자인 진행했습니다! 색상이나 hover시 동작은 헤더 부분 commute 버튼 참고했습니다.
        

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

### 📎 Reference
