### PR TITLE
[#94] Mainpage Lottie Error & commuteList desgin revise

### DIFF
--- a/src/components/Common/MainLottie/index.tsx
+++ b/src/components/Common/MainLottie/index.tsx
@@ -39,7 +39,7 @@ function MainLottie({ lottieData, width, height }: IMainLottieProps) {
 
 const StyledLottieContainer = styled.div`
   position: relative;
-  width: 100%;
+  width: 10%;
   margin: 0 auto;
   cursor: pointer;
 

--- a/src/components/CommuteList/index.tsx
+++ b/src/components/CommuteList/index.tsx
@@ -5,6 +5,10 @@ import { COMMUTE_LIST_STATE } from 'constants/time';
 import { media } from 'styles/media';
 import styled from 'styled-components';
 
+interface StyledListTextContainerProps {
+  align: 'left' | 'center' | 'right';
+}
+
 function CommuteList() {
   const [workTimeData, setWorkTimeData] = useState<IworkTimeResponse[]>([]);
 
@@ -14,7 +18,7 @@ function CommuteList() {
         const responseArray = await getWorkTimeData();
         if (responseArray) setWorkTimeData(responseArray);
       } catch (error) {
-        console.log('데이터를 불러오지 못했습니다.', error);
+        alert('데이터를 불러오지 못했습니다. 다시 시도해주세요.');
       }
     };
     fetchData();
@@ -31,11 +35,13 @@ function CommuteList() {
           .slice(COMMUTE_LIST_STATE.START_INDEX, COMMUTE_LIST_STATE.LAST_INDEX)
           .map((data, index) => (
             <StyledListContainer key={index}>
-              <StyledListTextContainer>{data.name}님</StyledListTextContainer>
-              <StyledListTextContainer>
+              <StyledListTextContainer align="left">
+                {data.name}님
+              </StyledListTextContainer>
+              <StyledListTextContainer align="center">
                 {secondFormat(data.workTime)}동안 근무하셨어요!
               </StyledListTextContainer>
-              <StyledListTextContainer>
+              <StyledListTextContainer align="right">
                 {dateFormat(new Date(data.timeStamp))}
               </StyledListTextContainer>
             </StyledListContainer>
@@ -58,22 +64,25 @@ const StyledEmptyListContainer = styled.div`
 
 const StyledListContainer = styled.div`
   display: flex;
+  align-items: center;
   justify-content: space-between;
   width: 80%;
   height: 3rem;
   border-bottom: 1px solid #eeeeee;
   margin: 0 auto;
-  margin-top: 2rem;
+  padding: 2.4rem;
 
   ${media.tablet(`
-  justify-content: space-around;
+  align-items: center;
   width: 100%;
   height: 2rem;
   margin: .5rem;
 `)}
 `;
 
-const StyledListTextContainer = styled.div`
+const StyledListTextContainer = styled.div<StyledListTextContainerProps>`
+  flex: 1;
+  text-align: ${(props) => props.align};
   ${media.tablet(`
   font-size: .8rem;
 `)}

--- a/src/pages/Main/index.tsx
+++ b/src/pages/Main/index.tsx
@@ -83,7 +83,6 @@ const StyledHrLine = styled.hr`
   border: 1px solid #c4c4c4;
   margin: 0 auto;
   margin-top: 2rem;
-  margin-bottom: 1rem;
 
   ${media.tablet(`
   margin-top: 1rem;


### PR DESCRIPTION
### ⛳️ Task

- [x] 메인 페이지 로티에 hover 효과시 상위 div 컨테이너의 css 속성에 따라 로티 외부에도 css 효과 및 스크롤 효과 적용 버그 발견 및 해결
- [x] 메인 페이지 근무 시간 리스트 렌더링 시 제대로 정렬되지 않던 문제 발견 및 해결

### ✍️ Note
근무 시간 리스트는 각 스타일 요소를 props로 전달 받아서 해결했습니다.


### ⚡️ Test
테스트 완료!

### 📸 Screenshot

https://github.com/energizer-develop/Y_FE_WIKI/assets/38286505/fa8e2ab0-09fe-4887-92b4-46f36e807e7a

### 📎 Reference


